### PR TITLE
Add unwatched://queue URL scheme

### DIFF
--- a/Unwatched/Unwatched/Extensions/Notification.swift
+++ b/Unwatched/Unwatched/Extensions/Notification.swift
@@ -9,5 +9,6 @@ extension Notification.Name {
     static let watchInUnwatched = Notification.Name("watchInUnwatched")
     static let pasteAndWatch = Notification.Name("pasteAndWatch")
     static let pasteAndQueue = Notification.Name("pasteAndQueue")
+    static let queueInUnwatched = Notification.Name("queueInUnwatched")
     static let searchYoutube = Notification.Name("searchYoutube")
 }

--- a/Unwatched/Unwatched/Helper/DeepLinkHandler.swift
+++ b/Unwatched/Unwatched/Helper/DeepLinkHandler.swift
@@ -70,6 +70,24 @@ struct DeepLinkHandler: ViewModifier {
             }
             let userInfo: [AnyHashable: Any] = ["youtubeUrl": youtubeUrl]
             NotificationCenter.default.post(name: .watchInUnwatched, object: nil, userInfo: userInfo)
+        case "queue":
+            // unwatched://queue?url=https://www.youtube.com/watch?v=O_0Wn73AnC8
+            // unwatched://queue?url=https://www.youtube.com/watch?v=O_0Wn73AnC8&next=true
+            guard
+                let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                let queryItems = components.queryItems
+            else { return }
+
+            guard
+                let youtubeUrlString = queryItems.first(where: { $0.name == "url" })?.value,
+                let youtubeUrl = URL(string: youtubeUrlString)
+            else {
+                Log.error("No youtube URL found in deep link: \(url)")
+                return
+            }
+            let isNext = queryItems.first(where: { $0.name == "next" })?.value == "true"
+            let queueUserInfo: [AnyHashable: Any] = ["youtubeUrl": youtubeUrl, "next": isNext]
+            NotificationCenter.default.post(name: .queueInUnwatched, object: nil, userInfo: queueUserInfo)
         default:
             break
         }

--- a/Unwatched/Unwatched/Helper/WatchNotificationHandlerViewModifier.swift
+++ b/Unwatched/Unwatched/Helper/WatchNotificationHandlerViewModifier.swift
@@ -19,6 +19,9 @@ struct WatchNotificationHandlerViewModifier: ViewModifier {
             .onReceive(NotificationCenter.default.publisher(for: .watchInUnwatched)) {
                 handleWatchInUnwatched($0)
             }
+            .onReceive(NotificationCenter.default.publisher(for: .queueInUnwatched)) {
+                handleQueueInUnwatched($0)
+            }
             .onReceive(NotificationCenter.default.publisher(for: .pasteAndWatch)) { _ in
                 handlePasteAndPlay()
             }
@@ -118,6 +121,19 @@ struct WatchNotificationHandlerViewModifier: ViewModifier {
         }
     }
 
+    func handleQueueInUnwatched(_ notification: NotificationCenter.Publisher.Output) {
+        Log.info("handleQueueInUnwatched")
+        if let userInfo = notification.userInfo,
+           let youtubeUrl = userInfo["youtubeUrl"] as? URL {
+            let isNext = userInfo["next"] as? Bool ?? false
+            if isNext {
+                addAndQueue(youtubeUrl)
+            } else {
+                addAndQueueAtBottom(youtubeUrl)
+            }
+        }
+    }
+
     func addAndPlay(_ url: URL) {
         let task = VideoService.addForeignUrls(
             [url],
@@ -133,6 +149,15 @@ struct WatchNotificationHandlerViewModifier: ViewModifier {
             [url],
             in: .queue,
             at: 1
+        )
+        player.loadTopmostVideoFromQueue(after: task, modelContext: modelContext, source: .nextUp)
+    }
+
+    func addAndQueueAtBottom(_ url: URL) {
+        let task = VideoService.addForeignUrls(
+            [url],
+            in: .queue,
+            at: -1
         )
         player.loadTopmostVideoFromQueue(after: task, modelContext: modelContext, source: .nextUp)
     }


### PR DESCRIPTION
New URL scheme `unwatched://queue` adds a video to the queue without starting playback.

> unwatched://queue?url=https://www.youtube.com/watch?v=VIDEO_ID
> unwatched://queue?url=https://www.youtube.com/watch?v=VIDEO_ID&next=true

where `next=true` queues next; false or omitted puts the added video at the bottom.

I know there's Shortcuts support for this, but I'd personally love to have a URL scheme to add without starting playback, like the current one does.

I believe I've followed the existing architecture:
  - `DeepLinkHandler` parses the URL and posts a `queueInUnwatched` notification
  - `WatchNotificationHandlerViewModifier` receives it and calls either `addAndQueue` (existing method, position 1, unchanged) or the new `addAndQueueAtBottom` (position -1, mirrors `addAndQueue`, the `-1` index is the same used in `.queueLast` placement).

addAndQueueAtBottom is actually the most "destructive" thing I've done because it's a new method, I don't know if you're ok with such approach.

Thanks for considering this!