### PR TITLE
Fix subscription refresh and preserve video state

### DIFF
--- a/Unwatched/Unwatched/Data/RSSParserDelegate.swift
+++ b/Unwatched/Unwatched/Data/RSSParserDelegate.swift
@@ -11,6 +11,8 @@ class RSSParserDelegate: NSObject, XMLParserDelegate {
     var videos: [SendableVideo] = []
     var subscriptionInfo: SendableSubscription?
     var limitVideos: Int?
+    var parsingSucceeded = false
+    var intentionallyStoppedParsing = false
 
     var currentElement = ""
     var currentTitle: String = ""
@@ -113,6 +115,7 @@ class RSSParserDelegate: NSObject, XMLParserDelegate {
                         currentUri.trimmingCharacters(in: .whitespacesAndNewlines)
                     )
                     subscriptionInfo?.youtubeChannelId = channelId
+                    intentionallyStoppedParsing = true
                     parser.abortParsing()
                     return
                 }

--- a/Unwatched/Unwatched/Data/VideoActor/VideoActor+Entries.swift
+++ b/Unwatched/Unwatched/Data/VideoActor/VideoActor+Entries.swift
@@ -42,7 +42,7 @@ extension VideoActor {
         let subId = sub.persistentModelID
         let past = Date.distantPast
         let fetch = FetchDescriptor<Video>(predicate: #Predicate {
-            $0.subscription?.persistentModelID == subId &&
+            ($0.subscription?.persistentModelID == subId || $0.subscription == nil) &&
                 ($0.publishedDate ?? past) >= oldestDate
         })
         return try? modelContext.fetch(fetch)
@@ -56,13 +56,22 @@ extension VideoActor {
         }
         var subVideosDict = [String: Video]()
         for video in subVideos {
+            let existing = subVideosDict[video.youtubeId]
+            if existing?.subscription != nil && video.subscription == nil {
+                continue
+            }
             subVideosDict[video.youtubeId] = video
         }
 
         var newVideos = [SendableVideo]()
+        var seenYouTubeIds = Set<String>()
         var imagesToBeDeleted = [URL]()
-        for video in videos {
+        for video in videos where seenYouTubeIds.insert(video.youtubeId).inserted {
             if let oldVideo = subVideosDict[video.youtubeId] {
+                if oldVideo.subscription == nil {
+                    oldVideo.subscription = sub
+                    oldVideo.youtubeChannelId = sub.youtubeChannelId
+                }
                 if oldVideo.updatedDate != video.updatedDate {
                     if let url = updateVideoAndGetImageToDelete(oldVideo, video) {
                         imagesToBeDeleted.append(url)

--- a/Unwatched/Unwatched/Data/VideoActor/VideoActor+Videos.swift
+++ b/Unwatched/Unwatched/Data/VideoActor/VideoActor+Videos.swift
@@ -4,6 +4,67 @@ import Observation
 import OSLog
 import UnwatchedShared
 
+struct SubscriptionVideoFetchResult: Sendable {
+    let subscription: SendableSubscription
+    let videos: [SendableVideo]?
+}
+
+enum SubscriptionFeedFetcher {
+    static let maxConcurrentFetches = 8
+
+    static func fetch(
+        _ subscriptions: [SendableSubscription],
+        maxConcurrent: Int = maxConcurrentFetches,
+        fetch: @escaping @Sendable (SendableSubscription) async throws -> [SendableVideo]
+    ) async -> [SubscriptionVideoFetchResult] {
+        guard !subscriptions.isEmpty else {
+            return []
+        }
+
+        let concurrency = max(1, min(maxConcurrent, subscriptions.count))
+        return await withTaskGroup(of: SubscriptionVideoFetchResult.self) { group in
+            var nextIndex = 0
+            var results = [SubscriptionVideoFetchResult]()
+            results.reserveCapacity(subscriptions.count)
+
+            func addNextFetch() {
+                guard nextIndex < subscriptions.count else {
+                    return
+                }
+                let subscription = subscriptions[nextIndex]
+                nextIndex += 1
+                group.addTask {
+                    do {
+                        return SubscriptionVideoFetchResult(
+                            subscription: subscription,
+                            videos: try await fetch(subscription)
+                        )
+                    } catch {
+                        Log.error(
+                            "Failed to fetch subscription \(subscription.title): "
+                                + error.localizedDescription
+                        )
+                        return SubscriptionVideoFetchResult(
+                            subscription: subscription,
+                            videos: nil
+                        )
+                    }
+                }
+            }
+
+            for _ in 0..<concurrency {
+                addNextFetch()
+            }
+
+            while let result = await group.next() {
+                results.append(result)
+                addNextFetch()
+            }
+            return results
+        }
+    }
+}
+
 // Video
 @ModelActor actor VideoActor {
     var newVideos = NewVideosNotificationInfo()
@@ -134,36 +195,42 @@ import UnwatchedShared
             consumeDeferredVideos()
         }
 
-        try await withThrowingTaskGroup(of: (SendableSubscription, [SendableVideo]).self) { group in
-            Log.info("loadVideos for \(sendableSubs.count) subscriptions")
-            for sub in sendableSubs {
-                group.addTask {
-                    try await self.fetchVideos(sub)
-                }
-            }
+        Log.info("loadVideos for \(sendableSubs.count) subscriptions")
+        let fetchResults = await SubscriptionFeedFetcher.fetch(sendableSubs) { sub in
+            try await self.fetchVideos(sub).1
+        }
 
-            var newVideoInfo = [(loadedVideos: [Video], addedVideos: [Video])]()
-            for try await (sub, videos) in group {
-                let result = await handleNewVideos(
-                    sub,
-                    videos,
-                    defaultPlacement: placementInfo
-                )
-                if result.addedVideos.count > 0 {
-                    // save sooner if videos got added
-                    try modelContext.save()
-                }
-                newVideoInfo.append(result)
+        var successfulFetchCount = 0
+        var newVideoInfo = [(loadedVideos: [Video], addedVideos: [Video])]()
+        for result in fetchResults {
+            guard let videos = result.videos else {
+                continue
             }
-            if fetchDurations {
-                try await handleFetchDurationsLoaded(
-                    newVideoInfo,
-                    onlyForAdded: subscriptionIds == nil // for all if specific subscription
-                )
+            successfulFetchCount += 1
+            let sub = result.subscription
+            let result = await handleNewVideos(
+                sub,
+                videos,
+                defaultPlacement: placementInfo
+            )
+            if result.addedVideos.count > 0 {
+                // save sooner if videos got added
+                try modelContext.save()
             }
+            newVideoInfo.append(result)
+        }
+        if fetchDurations {
+            try await handleFetchDurationsLoaded(
+                newVideoInfo,
+                onlyForAdded: subscriptionIds == nil // for all if specific subscription
+            )
         }
 
         await deferredVideosTask.value
+
+        if !sendableSubs.isEmpty && successfulFetchCount == 0 {
+            throw URLError(.badServerResponse)
+        }
 
         try modelContext.save()
         return newVideos

--- a/Unwatched/Unwatched/Data/VideoCrawler.swift
+++ b/Unwatched/Unwatched/Data/VideoCrawler.swift
@@ -15,14 +15,18 @@ struct VideoCrawler {
             throw URLError(.badServerResponse)
         }
 
-        return parseFeedData(data: data, limitVideos: limitVideos)
+        let delegate = parseFeedData(data: data, limitVideos: limitVideos)
+        guard delegate.parsingSucceeded || delegate.intentionallyStoppedParsing else {
+            throw VideoCrawlerError.failedToParse
+        }
+        return delegate
     }
 
     static func parseFeedData(data: Data, limitVideos: Int?) -> RSSParserDelegate {
         let parser = XMLParser(data: data)
         let rssParserDelegate = RSSParserDelegate(limitVideos: limitVideos)
         parser.delegate = rssParserDelegate
-        parser.parse()
+        rssParserDelegate.parsingSucceeded = parser.parse()
         return rssParserDelegate
     }
 

--- a/Unwatched/Unwatched/Service/CleanupService.swift
+++ b/Unwatched/Unwatched/Service/CleanupService.swift
@@ -393,13 +393,21 @@ struct CleanupService {
             return
         }
         removeMultipleEntries(from: videos)
-        let duplicates = getDuplicates(from: videos, keySelector: {
-            ($0.url?.absoluteString ?? "")
-        }, sort: sortVideos)
-        duplicateInfo.countVideos = duplicates.count
-        for duplicate in duplicates {
-            CleanupService.deleteVideo(duplicate, modelContext)
+
+        let groupedVideos = Dictionary(grouping: videos, by: \.youtubeId)
+        var duplicateCount = 0
+        for (_, group) in groupedVideos where group.count > 1 {
+            let sortedGroup = sortVideos(group)
+            guard let keeper = sortedGroup.first else {
+                continue
+            }
+            for duplicate in sortedGroup.dropFirst() {
+                mergeVideoState(from: duplicate, into: keeper)
+                CleanupService.deleteVideo(duplicate, modelContext)
+                duplicateCount += 1
+            }
         }
+        duplicateInfo.countVideos = duplicateCount
     }
 
     /// Removes inbox entry for videos that have both an inbox and queue entry, which should never be the case.
@@ -531,6 +539,43 @@ struct CleanupService {
 
     func sortWatchTimeEntries(_ entries: [WatchTimeEntry]) -> [WatchTimeEntry] {
         entries.sorted { $0.watchTime > $1.watchTime }
+    }
+}
+
+extension CleanupActor {
+    private func mergeVideoState(from duplicate: Video, into keeper: Video) {
+        if keeper.subscription == nil {
+            keeper.subscription = duplicate.subscription
+        }
+        if keeper.youtubeChannelId == nil {
+            keeper.youtubeChannelId = duplicate.youtubeChannelId
+        }
+
+        if keeper.inboxEntry == nil, let inboxEntry = duplicate.inboxEntry {
+            inboxEntry.video = keeper
+        }
+        if let duplicateQueueEntry = duplicate.queueEntry {
+            if let keeperQueueEntry = keeper.queueEntry {
+                keeperQueueEntry.order = min(keeperQueueEntry.order, duplicateQueueEntry.order)
+            } else {
+                duplicateQueueEntry.video = keeper
+            }
+        }
+
+        if let duplicateWatchedDate = duplicate.watchedDate,
+           duplicateWatchedDate > (keeper.watchedDate ?? .distantPast) {
+            keeper.watchedDate = duplicateWatchedDate
+        }
+        if (duplicate.elapsedSeconds ?? 0) > (keeper.elapsedSeconds ?? 0) {
+            keeper.elapsedSeconds = duplicate.elapsedSeconds
+        }
+        if keeper.bookmarkedDate == nil {
+            keeper.bookmarkedDate = duplicate.bookmarkedDate
+        }
+        if keeper.deferDate == nil {
+            keeper.deferDate = duplicate.deferDate
+        }
+        keeper.isNew = (keeper.isNew || duplicate.isNew) && keeper.watchedDate == nil
     }
 }
 

--- a/Unwatched/Unwatched/Service/UrlService.swift
+++ b/Unwatched/Unwatched/Service/UrlService.swift
@@ -44,14 +44,14 @@ struct UrlService {
         return URL(string: "mailto:unwatched@icloud.com?\(subject)body=\n\n\(body)")!
     }
 
-    static func getNonEmbeddedYoutubeUrl (_ youtubeId: String, _ startAt: Double? = nil) -> String {
+    static func getNonEmbeddedYoutubeUrl(_ youtubeId: String, _ startAt: Double? = nil) -> String {
         if let startAt {
             return "https://www.youtube.com/watch?v=\(youtubeId)&t=\(startAt)s"
         }
         return "https://www.youtube.com/watch?v=\(youtubeId)"
     }
 
-    static func getEmbeddedYoutubeUrl (_ youtubeId: String, _ startAt: Double) -> String {
+    static func getEmbeddedYoutubeUrl(_ youtubeId: String, _ startAt: Double) -> String {
         let useNoCookieUrl = UserDefaults.standard.bool(forKey: Const.useNoCookieUrl)
         let cookieUrl = useNoCookieUrl ? "-nocookie" : ""
         let disableCaptions = UserDefaults.standard.bool(forKey: Const.disableCaptions)
@@ -83,7 +83,7 @@ struct UrlService {
         return components.url
     }
 
-    static func stringContainsUrl (_ text: String) -> Bool {
+    static func stringContainsUrl(_ text: String) -> Bool {
         let regex = #"https?:\/\/\w+\.\w+"#
         return text.matching(regex: regex) != nil
     }

--- a/Unwatched/Unwatched/Service/UserDataService/UserDataService+Settings.swift
+++ b/Unwatched/Unwatched/Service/UserDataService/UserDataService+Settings.swift
@@ -8,9 +8,15 @@ import OSLog
 
 // MARK: - Settings Management
 extension UserDataService {
+    /// These settings describe the current installation and are unsafe to carry between
+    /// devices or between signed App Store builds and unsigned local builds.
+    private static let nonPortableSettings: Set<String> = [
+        Const.enableIcloudSync
+    ]
+
     static func getSettings() -> [String: AnyCodable] {
         var result = [String: AnyCodable]()
-        for (key, _) in Const.settingsDefaults {
+        for (key, _) in Const.settingsDefaults where !nonPortableSettings.contains(key) {
             if let value = UserDefaults.standard.object(forKey: key) {
                 result[key] = AnyCodable(value)
             } else {
@@ -33,6 +39,10 @@ extension UserDataService {
         }
         resetDefaultSettingsIfNeeded()
         for (key, value) in settings {
+            guard !nonPortableSettings.contains(key) else {
+                Log.info("Ignoring non-portable backup setting: \(key)")
+                continue
+            }
             if Const.syncedSettingsDefaults.contains(where: { $0.key == key }) {
                 NSUbiquitousKeyValueStore.default.set(value.value, forKey: key)
             } else {
@@ -54,7 +64,7 @@ extension UserDataService {
     }
 
     static private func resetDefaultSettingsIfNeeded() {
-        for (key, value) in Const.settingsDefaults {
+        for (key, value) in Const.settingsDefaults where !nonPortableSettings.contains(key) {
             let oldValue = UserDefaults.standard.object(forKey: key)
             if oldValue != nil {
                 UserDefaults.standard.setValue(value, forKey: key)

--- a/Unwatched/Unwatched/View/Chapter/ChapterSettingsMenu.swift
+++ b/Unwatched/Unwatched/View/Chapter/ChapterSettingsMenu.swift
@@ -129,7 +129,7 @@ struct CloudAiButton<Label: View>: View {
             components.queryItems = [
                 URLQueryItem(name: "name", value: name),
                 URLQueryItem(name: "x-success", value: successUrl),
-                URLQueryItem(name: "x-error", value: errorUrl),
+                URLQueryItem(name: "x-error", value: errorUrl)
             ]
             if let url = components.url {
                 if enablePip {

--- a/Unwatched/Unwatched/View/Player/FullscreenControls/FullscreenOverlayControls.swift
+++ b/Unwatched/Unwatched/View/Player/FullscreenControls/FullscreenOverlayControls.swift
@@ -100,8 +100,6 @@ struct FullscreenOverlayControls: View {
     }
 }
 
-
-
 enum OverlayIcon: Equatable {
     case play
     case pause

--- a/Unwatched/Unwatched/View/Player/MiniPlayerContent.swift
+++ b/Unwatched/Unwatched/View/Player/MiniPlayerContent.swift
@@ -6,7 +6,6 @@
 import SwiftUI
 import UnwatchedShared
 
-
 struct MiniPlayerContent: View {
     var videoTitle: String?
     var handleMiniPlayerTap: () -> Void

--- a/Unwatched/UnwatchedUITests/ExportableTests.swift
+++ b/Unwatched/UnwatchedUITests/ExportableTests.swift
@@ -226,7 +226,6 @@ class ExportableTests: XCTestCase {
                 // User Data
                 Const.automaticBackups: false,
                 Const.minimalBackups: false,
-                Const.enableIcloudSync: true,
                 Const.exludeWatchHistoryInBackup: true,
             ]
 
@@ -256,6 +255,17 @@ class ExportableTests: XCTestCase {
             XCTFail("Failed: \(error)")
             return
         }
+    }
+
+    func testICloudSyncSettingIsNotPortable() {
+        UserDefaults.standard.set(true, forKey: Const.enableIcloudSync)
+        XCTAssertNil(UserDataService.getSettings()[Const.enableIcloudSync])
+
+        UserDefaults.standard.set(false, forKey: Const.enableIcloudSync)
+        UserDataService.restoreSettings([
+            Const.enableIcloudSync: AnyCodable(true)
+        ])
+        XCTAssertFalse(UserDefaults.standard.bool(forKey: Const.enableIcloudSync))
     }
 
     func testSubscription() {
@@ -370,7 +380,5 @@ class ExportableTests: XCTestCase {
         }
     }
 }
-
-
 
 // swiftlint:enable all

--- a/Unwatched/UnwatchedUITests/VideoCrawlerTests.swift
+++ b/Unwatched/UnwatchedUITests/VideoCrawlerTests.swift
@@ -9,6 +9,165 @@ import UnwatchedShared
 
 class VideoCrawlerTests: XCTestCase {
 
+    actor FetchConcurrencyProbe {
+        private(set) var active = 0
+        private(set) var maximum = 0
+
+        func started() {
+            active += 1
+            maximum = max(maximum, active)
+        }
+
+        func finished() {
+            active -= 1
+        }
+    }
+
+    func makeInMemoryContainer() throws -> ModelContainer {
+        let schema = Schema(DataProvider.dbEntries)
+        let configuration = ModelConfiguration(
+            schema: schema,
+            isStoredInMemoryOnly: true,
+            cloudKitDatabase: .none
+        )
+        return try ModelContainer(for: schema, configurations: [configuration])
+    }
+
+    func testSubscriptionFetchesAreBoundedAndKeepPartialResults() async {
+        let subscriptions = (0..<12).map {
+            SendableSubscription(title: "subscription-\($0)")
+        }
+        let probe = FetchConcurrencyProbe()
+
+        let results = await SubscriptionFeedFetcher.fetch(
+            subscriptions,
+            maxConcurrent: 3
+        ) { subscription in
+            await probe.started()
+            try await Task.sleep(for: .milliseconds(20))
+            await probe.finished()
+
+            if subscription.title == "subscription-5" {
+                throw URLError(.badServerResponse)
+            }
+            return [SendableVideo(
+                youtubeId: subscription.title,
+                title: subscription.title,
+                url: nil
+            )]
+        }
+
+        let maximum = await probe.maximum
+        XCTAssertEqual(results.count, subscriptions.count)
+        XCTAssertEqual(results.compactMap(\.videos).count, subscriptions.count - 1)
+        XCTAssertEqual(maximum, 3)
+    }
+
+    func testExistingOrphanVideoIsReused() async throws {
+        let container = try makeInMemoryContainer()
+        let context = ModelContext(container)
+
+        let subscription = Subscription(
+            link: URL(string: "https://example.com/feed"),
+            title: "Subscription",
+            youtubeChannelId: "channel-id"
+        )
+        let orphan = Video(
+            title: "Existing",
+            url: URL(string: "https://youtube.com/watch?v=abcdefghijk"),
+            youtubeId: "abcdefghijk",
+            publishedDate: .now,
+            isYtShort: false
+        )
+        context.insert(subscription)
+        context.insert(orphan)
+        try context.save()
+
+        let actor = VideoActor(modelContainer: container)
+        let incoming = SendableVideo(
+            youtubeId: orphan.youtubeId,
+            title: "Existing",
+            url: orphan.url,
+            publishedDate: orphan.publishedDate,
+            isYtShort: false
+        )
+        let placement = DefaultVideoPlacement(
+            videoPlacement: .inbox,
+            hideShorts: false,
+            filterVideoTitleText: "",
+            allowOnMatch: false
+        )
+
+        guard let sendableSubscription = subscription.toExport else {
+            XCTFail("Could not export subscription")
+            return
+        }
+        _ = await actor.handleNewVideos(
+            sendableSubscription,
+            [incoming, incoming],
+            defaultPlacement: placement
+        )
+        try await actor.modelContext.save()
+
+        let verificationContext = ModelContext(container)
+        let videos = try verificationContext.fetch(FetchDescriptor<Video>())
+        XCTAssertEqual(videos.filter { $0.youtubeId == incoming.youtubeId }.count, 1)
+        XCTAssertEqual(videos.first?.subscription?.youtubeChannelId, "channel-id")
+    }
+
+    func testMalformedFeedReportsParseFailure() {
+        let data = Data("<feed><entry>".utf8)
+        let delegate = VideoCrawler.parseFeedData(data: data, limitVideos: nil)
+
+        XCTAssertFalse(delegate.parsingSucceeded)
+        XCTAssertFalse(delegate.intentionallyStoppedParsing)
+    }
+
+    func testDuplicateCleanupPreservesInboxAndPlaybackState() async throws {
+        let container = try makeInMemoryContainer()
+        let context = ModelContext(container)
+        let youtubeId = "abcdefghijk"
+        let subscription = Subscription(
+            link: URL(string: "https://example.com/feed"),
+            title: "Subscription",
+            youtubeChannelId: "channel-id"
+        )
+        let linkedVideo = Video(
+            title: "Linked",
+            url: URL(string: "https://youtube.com/watch?v=\(youtubeId)"),
+            youtubeId: youtubeId,
+            isYtShort: false
+        )
+        linkedVideo.subscription = subscription
+        let inboxVideo = Video(
+            title: "Inbox",
+            url: URL(string: "https://youtu.be/\(youtubeId)"),
+            youtubeId: youtubeId,
+            elapsedSeconds: 42,
+            watchedDate: .now,
+            isYtShort: false
+        )
+        context.insert(subscription)
+        context.insert(linkedVideo)
+        context.insert(inboxVideo)
+        context.insert(InboxEntry(inboxVideo))
+        try context.save()
+
+        let cleanupActor = CleanupActor(modelContainer: container)
+        let result = await cleanupActor.removeDuplicates(quickCheck: false, videoOnly: true)
+
+        let verificationContext = ModelContext(container)
+        let videos = try verificationContext.fetch(FetchDescriptor<Video>())
+        let inboxEntries = try verificationContext.fetch(FetchDescriptor<InboxEntry>())
+        XCTAssertEqual(result.countVideos, 1)
+        XCTAssertEqual(videos.count, 1)
+        XCTAssertEqual(videos.first?.subscription?.youtubeChannelId, "channel-id")
+        XCTAssertEqual(videos.first?.elapsedSeconds, 42)
+        XCTAssertNotNil(videos.first?.watchedDate)
+        XCTAssertEqual(inboxEntries.count, 1)
+        XCTAssertEqual(inboxEntries.first?.video?.youtubeId, youtubeId)
+    }
+
     func testParseDurationToSeconds() {
         let time = "PT3H2M27S"
         let duration = parseDurationToSeconds(time)

--- a/UnwatchedShared/UnwatchedShared/Data/DataProvider.swift
+++ b/UnwatchedShared/UnwatchedShared/Data/DataProvider.swift
@@ -5,6 +5,9 @@
 
 import SwiftData
 import OSLog
+#if os(macOS)
+import Security
+#endif
 
 public extension ProcessInfo {
     var isXcodePreview: Bool {
@@ -22,21 +25,48 @@ public final class DataProvider: Sendable {
         enableIcloudSync = true
         #endif
 
+        #if os(macOS)
+        if enableIcloudSync && !DataProvider.hasCloudKitContainerEntitlement {
+            Log.warning("Disabling iCloud sync: the app does not have the required CloudKit entitlement")
+            enableIcloudSync = false
+            UserDefaults.standard.set(false, forKey: Const.enableIcloudSync)
+        }
+        #endif
+
         #if DEBUG
         if CommandLine.arguments.contains("enable-testing") || ProcessInfo.processInfo.isXcodePreview {
             return DataProvider.previewContainer
         }
         #endif
 
-        let config = ModelConfiguration(
-            schema: DataProvider.schema,
-            isStoredInMemoryOnly: false,
-            cloudKitDatabase: enableIcloudSync ? .private("iCloud.com.pentlandFirth.Unwatched") : .none
-        )
-
-        Log.info("getModelContainer: config set")
-
+        #if os(macOS)
+        let storeURLs: [URL]
         do {
+            storeURLs = try DataProvider.storeURLs()
+        } catch {
+            fatalError("Could not prepare ModelContainer directory: \(error)")
+        }
+        #else
+        let storeURLs: [URL?] = [nil]
+        #endif
+
+        var lastError: Error?
+        for storeURL in storeURLs {
+            #if os(macOS)
+            Log.info("getModelContainer: trying store \(storeURL)")
+            let config = ModelConfiguration(
+                schema: DataProvider.schema,
+                url: storeURL,
+                cloudKitDatabase: enableIcloudSync ? .private("iCloud.com.pentlandFirth.Unwatched") : .none
+            )
+            #else
+            let config = ModelConfiguration(
+                schema: DataProvider.schema,
+                isStoredInMemoryOnly: false,
+                cloudKitDatabase: enableIcloudSync ? .private("iCloud.com.pentlandFirth.Unwatched") : .none
+            )
+            #endif
+
             do {
                 return try ModelContainer(
                     for: DataProvider.schema,
@@ -49,24 +79,77 @@ public final class DataProvider: Sendable {
 
             // workaround for migration (disable sync for initial launch)
             Log.info("getModelContainer: fallback")
-            let config = ModelConfiguration(
+            #if os(macOS)
+            let fallbackConfig = ModelConfiguration(
+                schema: DataProvider.schema,
+                url: storeURL,
+                cloudKitDatabase: .none
+            )
+            #else
+            let fallbackConfig = ModelConfiguration(
                 schema: DataProvider.schema,
                 isStoredInMemoryOnly: false,
                 cloudKitDatabase: .none
             )
-            let container = try ModelContainer(
-                for: DataProvider.schema,
-                migrationPlan: UnwatchedMigrationPlan.self,
-                configurations: [config]
-            )
-            Task { @MainActor in
-                DataProvider.migrationWorkaround(container.mainContext)
+            #endif
+
+            do {
+                let container = try ModelContainer(
+                    for: DataProvider.schema,
+                    migrationPlan: UnwatchedMigrationPlan.self,
+                    configurations: [fallbackConfig]
+                )
+                Task { @MainActor in
+                    DataProvider.migrationWorkaround(container.mainContext)
+                }
+                return container
+            } catch {
+                Log.error("getModelContainer fallback error: \(error)")
+                lastError = error
             }
-            return container
-        } catch {
-            fatalError("Could not create ModelContainer: \(error)")
         }
+
+        fatalError("Could not create ModelContainer: \(String(describing: lastError))")
     }()
+
+    #if os(macOS)
+    private static let hasCloudKitContainerEntitlement: Bool = {
+        guard let task = SecTaskCreateFromSelf(nil),
+              let containerIdentifiers = SecTaskCopyValueForEntitlement(
+                task,
+                "com.apple.developer.icloud-container-identifiers" as CFString,
+                nil
+              ) as? [String] else {
+            return false
+        }
+        return containerIdentifiers.contains("iCloud.com.pentlandFirth.Unwatched")
+    }()
+
+    /// Older builds used SwiftData's generic `default.store` directly in Application Support.
+    /// Try it for existing installs, then fall back to an app-specific store when it belongs
+    /// to another SwiftData app or has an unsupported schema.
+    private static func storeURLs(fileManager: FileManager = .default) throws -> [URL] {
+        let applicationSupportURL = URL.applicationSupportDirectory
+        let appDirectoryURL = applicationSupportURL.appending(
+            path: Const.bundleId,
+            directoryHint: .isDirectory
+        )
+        try fileManager.createDirectory(
+            at: appDirectoryURL,
+            withIntermediateDirectories: true
+        )
+
+        let appStoreURL = appDirectoryURL.appending(path: "default.store")
+        let legacyStoreURL = applicationSupportURL.appending(path: "default.store")
+        let appStoreExists = fileManager.fileExists(atPath: appStoreURL.path)
+        let legacyStoreExists = fileManager.fileExists(atPath: legacyStoreURL.path)
+
+        if !appStoreExists && legacyStoreExists {
+            return [legacyStoreURL, appStoreURL]
+        }
+        return [appStoreURL]
+    }
+    #endif
 
     private static func migrationWorkaround(_ context: ModelContext) {
         // workaround: migration fails during willMigrate (https://developer.apple.com/forums/thread/775060)


### PR DESCRIPTION
I encountered some issues when retrieving subscription feeds used by All Videos and Inbox, so I used my codex max subscription to try to fix things & after testing for a while on both mac and ios changes seem all to be working, so thought I'd share!:)

In some cases, a problem with one subscription could prevent the refresh from completing, and videos could be duplicated or lose their subscription association. I attempted to address those issues in this PR and would appreciate your review.


- Bound concurrent subscription-feed requests and preserved successful results when an individual feed fails.
- Reused existing orphaned videos when their YouTube ID matches a subscription feed.
- De-duplicated videos returned by feeds using their YouTube ID.
- Improved duplicate cleanup by preserving subscription, inbox, queue, watched-progress, bookmark, and defer state.
- Added explicit RSS parsing success/failure handling for malformed feeds.
- Improved macOS SwiftData storage and CloudKit entitlement handling.
- Prevented the iCloud-sync preference from being transferred through settings backups.
- Added regression tests for the affected cases.

I added regression coverage for partial feed failures, bounded concurrency, orphaned videos, malformed feeds, duplicate cleanup, and non-portable iCloud settings. I have not yet run the full Xcode test suite.

This is my first attempt to address these issues, so I would be grateful for any feedback or suggestions for fitting the changes into the project’s conventions.